### PR TITLE
fix: Resolve Vercel build errors

### DIFF
--- a/components/admin/analytics-viewer.tsx
+++ b/components/admin/analytics-viewer.tsx
@@ -79,7 +79,7 @@ export default function AnalyticsViewer() {
             <p className="text-gray-500 text-lg">No hay datos de analíticas disponibles aún.</p>
             <Button onClick={fetchAnalytics} className="mt-6">Refrescar</Button>
         </div>
-    ),
+    );
   }
 
   const renderProductList = (products: AnalyticsProductSummary[], metric: "count" | "totalQuantity", unit: string) => {

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "latest",
     "@hookform/resolvers": "^3.9.1",
+    "@prisma/client": "^5.12.1",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",
@@ -66,6 +67,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "postcss": "^8",
+    "prisma": "^5.12.1",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"
   }


### PR DESCRIPTION
This commit addresses critical errors that caused the Vercel build to fail.

1.  **Correct JSX Syntax in `analytics-viewer.tsx`**: Fixed a JSX syntax error (a misplaced comma after a return statement) in `components/admin/analytics-viewer.tsx` that prevented successful parsing.

2.  **Update Prisma Dependencies in `package.json`**:
    *   Moved `@prisma/client` to `dependencies` to ensure it's available in the production environment on Vercel.
    *   Added `prisma` (CLI) to `devDependencies` for development and build-time generation.

3.  **Ensure Prisma Client Generation in Build Process**:
    *   Modified the `scripts.build` command in `package.json` to `"prisma generate && next build"`. This ensures Prisma Client is generated before Next.js builds the application, resolving module resolution issues for `@prisma/client` in production.

These changes should allow the Vercel deployment to build and run successfully.