### PR TITLE
Fix: Convert Decimal to string for product prices

### DIFF
--- a/app/actions/menuActions.ts
+++ b/app/actions/menuActions.ts
@@ -33,6 +33,7 @@ export async function getPublicMenuData() {
     const menuDataMap = categoriesWithProductsAndVariants.reduce((acc, category) => {
       acc[category.name] = category.products.map(product => ({
         ...product,
+        price: product.price.toString(), // Convert price to string
         // Assuming variants is the correct field name from Prisma
         // and that the full variant objects are desired.
         // If only variant names were needed, it would be:

--- a/components/menu/menu-item-card.tsx
+++ b/components/menu/menu-item-card.tsx
@@ -41,7 +41,7 @@ export default function MenuItemCard({ item, onItemClick }: MenuItemCardProps) {
           <h3 className="font-semibold text-gray-800 mb-1">{item.name}</h3>
           <p className="text-sm text-gray-600 mb-3 line-clamp-2">{item.description}</p>
           <div className="flex items-center justify-between">
-            <span className="text-lg font-bold text-gray-800">S/ {item.price.toFixed(2)}</span>
+            <span className="text-lg font-bold text-gray-800">S/ {parseFloat(item.price as any).toFixed(2)}</span>
           </div>
           <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} className="mt-3">
             <Button

--- a/components/modals/product-detail-modal.tsx
+++ b/components/modals/product-detail-modal.tsx
@@ -58,7 +58,7 @@ export default function ProductDetailModal({ isOpen, onClose, product, onAddToCa
   }
 
   const getTotalPrice = () => {
-    return product.price * getTotalQuantity()
+    return parseFloat(product.price as any) * getTotalQuantity()
   }
 
   const handleAddToCart = () => {

--- a/components/screens/menu-screen.tsx
+++ b/components/screens/menu-screen.tsx
@@ -111,7 +111,7 @@ export default function MenuScreen({ customerName, orderType, onBack }: MenuScre
   }
 
   const getTotalPrice = () => {
-    return cart.reduce((total, item) => total + item.price * item.quantity, 0)
+    return cart.reduce((total, item) => total + parseFloat(item.price) * item.quantity, 0)
   }
 
   const getTotalItems = () => {


### PR DESCRIPTION
Serializing Decimal objects from Server Components to Client Components is not supported in Next.js and was causing a runtime error.

This commit fixes the issue by:
- Modifying the `getPublicMenuData` server action in `app/actions/menuActions.ts` to convert the `product.price` (Decimal) to a string using `toString()` before returning the data to client components.
- Updating client components (`components/screens/menu-screen.tsx`, `components/modals/product-detail-modal.tsx`, and `components/menu/menu-item-card.tsx`) to handle the string-based price, using `parseFloat()` for calculations and `toFixed(2)` for display, ensuring correct functionality.